### PR TITLE
Fix some erros in setup.sh

### DIFF
--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -55,21 +55,26 @@ msg() {
 
 setup_colors
 
-read -r -p "Enter a disambiguation prefix (try initials with a sequence number, such as ejb01): " DISAMBIG_PREFIX
+read -r -p "Enter a disambiguation prefix (try initials with a sequence number, default is ejb01): " DISAMBIG_PREFIX
 
-if [ "$DISAMBIG_PREFIX" == '' ] ; then
-  msg "${RED}You must enter a disambiguation prefix."
-  exit 1;
+if [ -z "$DISAMBIG_PREFIX" ]; then
+  DISAMBIG_PREFIX="ejb01"
+  echo "Using disambiguation prefix: $DISAMBIG_PREFIX"
 fi
 
+
 # get ORC_SSOUSER if not set at the beginning of this file
-if [ "$ORC_SSOUSER" == '' ] ; then
-    read -r -p "Enter Oracle single sign-on userid: " ORC_SSOUSER
+if [[ -z "$ORC_SSOUSER" ]]; then
+    while [[ -z "$ORC_SSOUSER" ]]; do
+        read -r -p "Enter Oracle single sign-on userid: " ORC_SSOUSER
+    done
 fi
 
 # get ORC_SSOPSW if not set at the beginning of this file
-if [ "$ORC_SSOPSW" == '' ] ; then
-    read -s -r -p "Enter password for preceding Oracle single sign-on userid: " ORC_SSOPSW
+if [[ -z "$ORC_SSOPSW" ]]; then
+    while [[ -z "$ORC_SSOPSW" ]]; do
+        read -s -r -p "Enter password for preceding Oracle single sign-on userid: " ORC_SSOPSW
+    done
 fi
 
 echo -e "\n"
@@ -146,7 +151,7 @@ SP_OBJECT_ID_ARRAY=$(az ad sp list --display-name ${SERVICE_PRINCIPAL_NAME} --qu
 SP_OBJECT_ID_ARRAY=$(echo ${SP_OBJECT_ID_ARRAY} | xargs) || true
 SP_OBJECT_ID_ARRAY=${SP_OBJECT_ID_ARRAY//[/}
 SP_OBJECT_ID=${SP_OBJECT_ID_ARRAY//]/}
-az role assignment create --assignee ${SP_OBJECT_ID} --role "User Access Administrator" --subscription "${SUBSCRIPTION_ID}"
+az role assignment create --assignee ${SP_OBJECT_ID} --role "User Access Administrator" --subscription "${SUBSCRIPTION_ID}"  --scope "/subscriptions/${SUBSCRIPTION_ID}"
 
 msg "${GREEN}(4/4) Create secrets in GitHub"
 if $USE_GITHUB_CLI; then

--- a/.github/workflows/setupWlsAks.yml
+++ b/.github/workflows/setupWlsAks.yml
@@ -13,7 +13,7 @@ on:
     
 env:
   aksRepoUserName: oracle
-  aksRepoBranchName: 364b7648bbe395cb17683180401d07a3029abe91
+  aksRepoBranchName: 042a47ae4dad755dfafdb30cfbdb753a24194984
   aksClusterConfigMapName: wlsd-wdt-config-map-${{ github.event.inputs.disambiguationSuffix }}
   appInsightName: wlsakscargotracker${{ github.run_id }}
   azCliVersion: 2.40.0

--- a/.github/workflows/setupWlsAks.yml
+++ b/.github/workflows/setupWlsAks.yml
@@ -13,7 +13,7 @@ on:
     
 env:
   aksRepoUserName: oracle
-  aksRepoBranchName: 95bd2e7258ac97ac1b82c59eed82a0492653794f
+  aksRepoBranchName: 364b7648bbe395cb17683180401d07a3029abe91
   aksClusterConfigMapName: wlsd-wdt-config-map-${{ github.event.inputs.disambiguationSuffix }}
   appInsightName: wlsakscargotracker${{ github.run_id }}
   azCliVersion: 2.40.0

--- a/.github/workflows/setupWlsAks.yml
+++ b/.github/workflows/setupWlsAks.yml
@@ -13,7 +13,7 @@ on:
     
 env:
   aksRepoUserName: oracle
-  aksRepoBranchName: 364b7648bbe395cb17683180401d07a3029abe91
+  aksRepoBranchName: 95bd2e7258ac97ac1b82c59eed82a0492653794f
   aksClusterConfigMapName: wlsd-wdt-config-map-${{ github.event.inputs.disambiguationSuffix }}
   appInsightName: wlsakscargotracker${{ github.run_id }}
   azCliVersion: 2.40.0

--- a/.scripts/setup-env-variables-template.sh
+++ b/.scripts/setup-env-variables-template.sh
@@ -1,4 +1,4 @@
-export WLS_AKS_REPO_REF="364b7648bbe395cb17683180401d07a3029abe91" # oracle/weblogic-azure reference
+export WLS_AKS_REPO_REF="95bd2e7258ac97ac1b82c59eed82a0492653794f" # oracle/weblogic-azure reference
 export RESOURCE_GROUP_NAME="abc1110rg" # customize this
 export STORAGE_ACCOUNT_NAME="stgwlsaks$(date +%s)" # storage account name
 export DB_SERVER_NAME="wlsdb$(date +%s)" # PostgreSQL server name

--- a/.scripts/setup-env-variables-template.sh
+++ b/.scripts/setup-env-variables-template.sh
@@ -1,4 +1,4 @@
-export WLS_AKS_REPO_REF="364b7648bbe395cb17683180401d07a3029abe91" # oracle/weblogic-azure reference
+export WLS_AKS_REPO_REF="042a47ae4dad755dfafdb30cfbdb753a24194984" # oracle/weblogic-azure reference
 export RESOURCE_GROUP_NAME="abc1110rg" # customize this
 export STORAGE_ACCOUNT_NAME="stgwlsaks$(date +%s)" # storage account name
 export DB_SERVER_NAME="wlsdb$(date +%s)" # PostgreSQL server name

--- a/.scripts/setup-env-variables-template.sh
+++ b/.scripts/setup-env-variables-template.sh
@@ -1,4 +1,4 @@
-export WLS_AKS_REPO_REF="95bd2e7258ac97ac1b82c59eed82a0492653794f" # oracle/weblogic-azure reference
+export WLS_AKS_REPO_REF="364b7648bbe395cb17683180401d07a3029abe91" # oracle/weblogic-azure reference
 export RESOURCE_GROUP_NAME="abc1110rg" # customize this
 export STORAGE_ACCOUNT_NAME="stgwlsaks$(date +%s)" # storage account name
 export DB_SERVER_NAME="wlsdb$(date +%s)" # PostgreSQL server name

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ cp ${DIR}/cargotracker/.scripts/setup-env-variables-template.sh ${DIR}/cargotrac
 Open `${DIR}/cargotracker/.scripts/setup-env-variables.sh` and enter the following information. Make sure your Oracle SSO user name and password are correct.
 
 ```bash
-export WLS_AKS_REPO_REF="95bd2e7258ac97ac1b82c59eed82a0492653794f" # oracle/weblogic-azure reference
+export WLS_AKS_REPO_REF="364b7648bbe395cb17683180401d07a3029abe91" # oracle/weblogic-azure reference
 export RESOURCE_GROUP_NAME="abc1110rg" # customize this
 export STORAGE_ACCOUNT_NAME="stgwlsaks$(date +%s)" # storage account name
 export DB_SERVER_NAME="wlsdb$(date +%s)" # PostgreSQL server name
@@ -114,7 +114,7 @@ source ${DIR}/cargotracker/.scripts/setup-env-variables.sh
 
 ### Clone WLS on AKS Bicep templates
 
-Clone the Bicep templates from [oracle/weblogic-azure](https://github.com/oracle/weblogic-azure). This quickstart was tested with [commit 364b764](https://github.com/oracle/weblogic-azure/commit/95bd2e7258ac97ac1b82c59eed82a0492653794f). 
+Clone the Bicep templates from [oracle/weblogic-azure](https://github.com/oracle/weblogic-azure). This quickstart was tested with [commit 364b764](https://github.com/oracle/weblogic-azure/commit/364b7648bbe395cb17683180401d07a3029abe91). 
 
 ```bash
 git clone https://github.com/oracle/weblogic-azure.git ${DIR}/weblogic-azure

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ cp ${DIR}/cargotracker/.scripts/setup-env-variables-template.sh ${DIR}/cargotrac
 Open `${DIR}/cargotracker/.scripts/setup-env-variables.sh` and enter the following information. Make sure your Oracle SSO user name and password are correct.
 
 ```bash
-export WLS_AKS_REPO_REF="364b7648bbe395cb17683180401d07a3029abe91" # oracle/weblogic-azure reference
+export WLS_AKS_REPO_REF="042a47ae4dad755dfafdb30cfbdb753a24194984" # oracle/weblogic-azure reference
 export RESOURCE_GROUP_NAME="abc1110rg" # customize this
 export STORAGE_ACCOUNT_NAME="stgwlsaks$(date +%s)" # storage account name
 export DB_SERVER_NAME="wlsdb$(date +%s)" # PostgreSQL server name
@@ -114,7 +114,7 @@ source ${DIR}/cargotracker/.scripts/setup-env-variables.sh
 
 ### Clone WLS on AKS Bicep templates
 
-Clone the Bicep templates from [oracle/weblogic-azure](https://github.com/oracle/weblogic-azure). This quickstart was tested with [commit 364b764](https://github.com/oracle/weblogic-azure/commit/364b7648bbe395cb17683180401d07a3029abe91). 
+Clone the Bicep templates from [oracle/weblogic-azure](https://github.com/oracle/weblogic-azure). This quickstart was tested with [commit 364b764](https://github.com/oracle/weblogic-azure/commit/042a47ae4dad755dfafdb30cfbdb753a24194984). 
 
 ```bash
 git clone https://github.com/oracle/weblogic-azure.git ${DIR}/weblogic-azure

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ cp ${DIR}/cargotracker/.scripts/setup-env-variables-template.sh ${DIR}/cargotrac
 Open `${DIR}/cargotracker/.scripts/setup-env-variables.sh` and enter the following information. Make sure your Oracle SSO user name and password are correct.
 
 ```bash
-export WLS_AKS_REPO_REF="364b7648bbe395cb17683180401d07a3029abe91" # oracle/weblogic-azure reference
+export WLS_AKS_REPO_REF="95bd2e7258ac97ac1b82c59eed82a0492653794f" # oracle/weblogic-azure reference
 export RESOURCE_GROUP_NAME="abc1110rg" # customize this
 export STORAGE_ACCOUNT_NAME="stgwlsaks$(date +%s)" # storage account name
 export DB_SERVER_NAME="wlsdb$(date +%s)" # PostgreSQL server name
@@ -114,7 +114,7 @@ source ${DIR}/cargotracker/.scripts/setup-env-variables.sh
 
 ### Clone WLS on AKS Bicep templates
 
-Clone the Bicep templates from [oracle/weblogic-azure](https://github.com/oracle/weblogic-azure). This quickstart was tested with [commit 364b764](https://github.com/oracle/weblogic-azure/commit/364b7648bbe395cb17683180401d07a3029abe91). 
+Clone the Bicep templates from [oracle/weblogic-azure](https://github.com/oracle/weblogic-azure). This quickstart was tested with [commit 364b764](https://github.com/oracle/weblogic-azure/commit/95bd2e7258ac97ac1b82c59eed82a0492653794f). 
 
 ```bash
 git clone https://github.com/oracle/weblogic-azure.git ${DIR}/weblogic-azure


### PR DESCRIPTION
## Changes
1. Give DISAMBIG_PREFIX a default value.
2. To prevent users from accidentally entering empty spaces.
3. Fix error while users configure default resource group and the the resource group don't exist in Azure.
4. Fix WLS_AKS_REPO_REF
  - Old value of WLS_AKS_REPO_REF: 364b7648b
  - New value of WLS_AKS_REPO_REF: 042a47ae4
  The way to get replicas in setupDBConnections.sh between commit [364b7648b](https://github.com/azure-javaee/weblogic-azure/blob/364b7648bbe395cb17683180401d07a3029abe91/weblogic-azure-aks/src/main/arm/scripts/setupDBConnections.sh#L195-L196) and commit [042a47ae4](https://github.com/azure-javaee/weblogic-azure/blob/042a47ae4dad755dfafdb30cfbdb753a24194984/weblogic-azure-aks/src/main/arm/scripts/setupDBConnections.sh#L202-L203)  are different, commit[364b7648b](https://github.com/azure-javaee/weblogic-azure/blob/364b7648bbe395cb17683180401d07a3029abe91/weblogic-azure-aks/src/main/arm/scripts/setupDBConnections.sh#L195-L196) not work.

## Test
✅ Github actions [passed](https://github.com/backwind1233/cargotracker-wls-aks/actions/runs/5873649759). 
<img width="430" alt="image" src="https://github.com/Azure-Samples/cargotracker-wls-aks/assets/4465723/278cd8ff-dd79-48f0-b568-f9aa8320184d">
