### PR TITLE
The variable `deleteResource` is not set correctly for scheduled workflow

### DIFF
--- a/.github/workflows/setupWlsAks.yml
+++ b/.github/workflows/setupWlsAks.yml
@@ -51,12 +51,12 @@ jobs:
         id: setup-env-variables
         run: |
           disambiguationSuffix=${{ github.event.inputs.disambiguationSuffix }}
-          if [ ${{ github.event.inputs.disambiguationSuffix }} == '' ]; then
+          if [ -z "${disambiguationSuffix}" ]; then
             disambiguationSuffix=wls`date +%m%d`
           fi
 
           deleteResource=${{ github.event.inputs.deleteResource }}
-          if [ ${{ github.event.inputs.deleteResource }} == '' ]; then
+          if [ -z "${deleteResource}" ]; then
             deleteResource='true'
           fi
 


### PR DESCRIPTION
When the workflow is scheduled, azure resources are not deleted. See pipeline https://github.com/azure-javaee/cargotracker-liberty-aks/actions/runs/8444891837/job/23132288938.

This PR is to initialize the `deleteResource ` correctly. Make sure resources are deleted.