### PR TITLE
Update the tag of the dependency weblogic-azure.

### DIFF
--- a/.github/workflows/setupWlsAks.yml
+++ b/.github/workflows/setupWlsAks.yml
@@ -106,7 +106,7 @@ jobs:
               --server-name ${{ env.dbName }} \
               --database-name ${{ env.dbServerName }}
 
-            sleep 1m
+            sleep 2m
             echo "Allow Access To Azure Services"
             az postgres flexible-server firewall-rule create \
               -g ${{ env.resourceGroupForDB }} \

--- a/.github/workflows/setupWlsAks.yml
+++ b/.github/workflows/setupWlsAks.yml
@@ -20,7 +20,7 @@ on:
     
 env:
   aksRepoUserName: ${{ secrets.AKS_REPO_USER_NAME }}
-  aksRepoBranchName: 2024-03-21-1-Q1
+  aksRepoBranchName: 2024-06-04-1-Q2
   appInsightName: wlsakscargotracker${{ github.run_id }}
   azCliVersion: 2.60.0
   azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ cp ${DIR}/cargotracker/src/test/aks/setup-env-variables-template.sh ${DIR}/cargo
 Open `${DIR}/cargotracker/src/test/aks/setup-env-variables.sh` and enter the following information. Make sure your Oracle SSO user name and password are correct.
 
 ```bash
-export WLS_AKS_REPO_REF="2024-03-21-1-Q1" # oracle/weblogic-azure reference
+export WLS_AKS_REPO_REF="2024-06-04-1-Q2" # oracle/weblogic-azure reference
 export RESOURCE_GROUP_NAME="abc1110rg" # customize this
 export STORAGE_ACCOUNT_NAME="stgwlsaks$(date +%s)" # storage account name
 export DB_SERVER_NAME="wlsserverdb$(date +%s)" # PostgreSQL server name
@@ -222,7 +222,7 @@ DB_CONNECTION_STRING="jdbc:postgresql://${DB_SERVER_NAME}.postgres.database.azur
 
 ### Prepare deployment parameters
 
-In the following sections, you use solution templates in [oralce/weblogic-azure](https://github.com/oracle/weblogic-azure/tree/2024-03-21-1-Q1/weblogic-azure-aks/src/main/arm) to provision resources. Several parameters are required to invoke [mainTemplate.json](https://github.com/oracle/weblogic-azure/blob/2024-03-21-1-Q1/weblogic-azure-aks/src/main/arm/mainTemplate.json). Parameters and their value are listed in the table. Make sure the variables have correct value.
+In the following sections, you use solution templates in [oralce/weblogic-azure](https://github.com/oracle/weblogic-azure/tree/2024-06-04-1-Q2/weblogic-azure-aks/src/main/arm) to provision resources. Several parameters are required to invoke [mainTemplate.json](https://github.com/oracle/weblogic-azure/blob/2024-06-04-1-Q2/weblogic-azure-aks/src/main/arm/mainTemplate.json). Parameters and their value are listed in the table. Make sure the variables have correct value.
 
 | Parameter Name | Value | Note |
 | -------------| ---------- | -----------------|

--- a/src/test/aks/setup-env-variables-template.sh
+++ b/src/test/aks/setup-env-variables-template.sh
@@ -1,4 +1,4 @@
-export WLS_AKS_REPO_REF="2024-03-21-1-Q1" # oracle/weblogic-azure reference
+export WLS_AKS_REPO_REF="2024-06-04-1-Q2" # oracle/weblogic-azure reference
 export RESOURCE_GROUP_NAME="abc1110rg" # customize this
 export STORAGE_ACCOUNT_NAME="stgwlsaks$(date +%s)" # storage account name
 export DB_SERVER_NAME="wlsserverdb$(date +%s)" # PostgreSQL server name


### PR DESCRIPTION
This pull request mainly includes updates to the `WLS_AKS_REPO_REF` reference and `sleep` command duration in the `.github/workflows/setupWlsAks.yml` and `README.md` files. The `WLS_AKS_REPO_REF` reference has been updated from `2024-03-21-1-Q1` to `2024-06-04-1-Q2` in multiple files. Additionally, the `sleep` command duration in the `.github/workflows/setupWlsAks.yml` file has been increased from 1 minute to 2 minutes.

Updates to `WLS_AKS_REPO_REF` reference:

* [`.github/workflows/setupWlsAks.yml`](diffhunk://#diff-440379d172f6fbfb9e3de676630f19d20375d242ba544c19c290ab37d4b56db5L23-R23): Updated `WLS_AKS_REPO_REF` reference in the `env:` section.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L96-R96): Updated `WLS_AKS_REPO_REF` reference in the `cp ${DIR}/cargotracker/src/test/aks/setup-env-variables-template.sh ${DIR}/cargo` section and in the `DB_CONNECTION_STRING="jdbc:postgresql://${DB_SERVER_NAME}.postgres.database.azur` section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L96-R96) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L225-R225)
* [`src/test/aks/setup-env-variables-template.sh`](diffhunk://#diff-71380dcc9963bc716d9ce7f6026bb6d1ac73a0bb0d29dfba56dbcd01046494fcL1-R1): Updated `WLS_AKS_REPO_REF` reference.

Change to `sleep` command duration:

* [`.github/workflows/setupWlsAks.yml`](diffhunk://#diff-440379d172f6fbfb9e3de676630f19d20375d242ba544c19c290ab37d4b56db5L109-R109): Increased `sleep` command duration from 1 minute to 2 minutes in the `jobs:` section.

Test: https://github.com/azure-javaee/cargotracker-wls-aks/actions/runs/9475991009